### PR TITLE
Check if the wall jump is enabled in the mod settings

### DIFF
--- a/P06Extended/XPlayerBase.cs
+++ b/P06Extended/XPlayerBase.cs
@@ -418,7 +418,8 @@
                 // If is wall jumping already - I can't extend the state enum ...
                 if (WallJump.IsWallJumping) return false;
 
-                // TODO: Add check if the wall jump is enabled in the mod settings...
+                // Check if the wall jump is enabled in the mod settings.
+                if (!XDebug.Instance.Moveset_WallJumping.Value) return false;
 
                 if (I.I.GetPrefab("omega") && !I.Boo["FrontalCollision"])
                 {


### PR DESCRIPTION
Previously the wall jump was enabled regardless of the toggle in the settings. Now wall  jumping is possible if and only if wall jumping is enabled in the mod settings.

Teested manually by jumping against a well with disabled wall jumping option.